### PR TITLE
Fix to get the value of videoFifoRead properly

### DIFF
--- a/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
+++ b/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
@@ -627,7 +627,7 @@ void FFmpegVideoReader::DecoderThread::setCurrentPTS (const double pts, bool see
         return;
     }
 
-    auto read = videoFifoRead;
+    auto read = videoFifoRead.load();
     auto i=0;
 
     while ((videoFrames [(read + i) % videoFrames.size()].first < pts) && i < (availableFrames - 1)) {


### PR DESCRIPTION
std::atomic<> has a deleted assignment operator, need to use std::atomic<>::load() to compile...