### PR TITLE
Fix crash and conversion issues with audio in some video formats.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docs/
 examples/VideoPlayer/Builds/VisualStudio2015/Win32/
 *.db
 *.opendb
+.DS_Store

--- a/examples/VideoPlayer/VideoPlayer.jucer
+++ b/examples/VideoPlayer/VideoPlayer.jucer
@@ -14,7 +14,7 @@
   </MAINGROUP>
   <EXPORTFORMATS>
     <XCODE_MAC targetFolder="Builds/MacOSX" extraCompilerFlags="-Wno-reserved-user-defined-literal&#10;-I${FFMPEG_ROOT}/include"
-               extraLinkerFlags="-L${FFMPEG_ROOT}/lib" externalLibraries="avformat&#10;avutil&#10;avcodec&#10;swscale&#10;swresample"
+               extraLinkerFlags="-L${FFMPEG_ROOT}/lib" externalLibraries="avformat&#10;avutil&#10;avcodec&#10;swscale&#10;swresample&#10;avresample"
                extraDefs="FFMPEG_ROOT=/usr/local">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="VideoPlayer"
@@ -43,7 +43,7 @@
     </XCODE_MAC>
     <VS2015 targetFolder="Builds/VisualStudio2015" extraCompilerFlags="-I../../../../../../FFmpeg/build/windows/include"
             extraLinkerFlags="-LIBPATH:../../../../../../FFmpeg/build/windows/bin"
-            externalLibraries="avformat.lib&#10;avutil.lib&#10;avcodec.lib&#10;swscale.lib&#10;swresample.lib">
+            externalLibraries="avformat.lib&#10;avutil.lib&#10;avcodec.lib&#10;swscale.lib&#10;swresample.lib&#10;avresample.lib">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" winWarningLevel="4" generateManifest="1" winArchitecture="32-bit"
                        isDebug="1" optimisation="1" targetName="VideoLibTest" debugInformationFormat="ProgramDatabase"

--- a/modules/filmstro_audiohelpers/filmstro_audiohelpers_AudioBufferFIFO.h
+++ b/modules/filmstro_audiohelpers/filmstro_audiohelpers_AudioBufferFIFO.h
@@ -81,23 +81,23 @@ public:
     }
 
     /*< Push samples from an AudioBuffer into the FIFO */
-    void addToFifo (const juce::AudioBuffer<FloatType>& samples, int numSamples=-1)
+    void addToFifo (const juce::AudioBuffer<FloatType>& samples, int numSamples = -1, int sourceOffset = 0)
     {
-        const int addSamples = numSamples < 0 ? samples.getNumSamples() : numSamples;
+        const int addSamples = (numSamples < 0 ? samples.getNumSamples() : numSamples) - sourceOffset;
         jassert (getFreeSpace() >= addSamples);
-
+        
         int start1, size1, start2, size2;
         prepareToWrite (addSamples, start1, size1, start2, size2);
         if (size1 > 0)
             for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
-                buffer.copyFrom (channel, start1, samples.getReadPointer (channel), size1);
+                buffer.copyFrom (channel, start1, samples.getReadPointer (channel, sourceOffset), size1);
         if (size2 > 0)
             for (int channel = 0; channel < buffer.getNumChannels(); ++channel)
-                buffer.copyFrom (channel, start2, samples.getReadPointer (channel, size1), size2);
+                buffer.copyFrom (channel, start2, samples.getReadPointer (channel, sourceOffset + size1), size2);
         finishedWrite (size1 + size2);
-
+        
     }
-
+    
     /*< Read samples from the FIFO into raw float arrays */
     void readFromFifo (FloatType** samples, int numSamples)
     {

--- a/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
+++ b/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
@@ -347,6 +347,12 @@ FFmpegVideoReader::DecoderThread::~DecoderThread ()
 
 }
 
+std::string averrtostr(int errnum)
+{
+       char errstr[AV_ERROR_MAX_STRING_SIZE] = { 0 };
+       av_make_error_string(errstr, AV_ERROR_MAX_STRING_SIZE, errnum);
+       return std::string(errstr);
+}
 
 bool FFmpegVideoReader::DecoderThread::loadMovieFile (const juce::File& inputFile)
 {
@@ -381,7 +387,7 @@ bool FFmpegVideoReader::DecoderThread::loadMovieFile (const juce::File& inputFil
                                                    NULL);                // log_ctx
         ret = swr_init(audioConverterContext);
         if(ret < 0)
-            fprintf(stderr, "Error initialising audio converter: %s\n", av_err2str(ret));
+            std::cerr << "Error initialising audio converter: " << averrtostr(ret) << std::endl;
     }
 
     videoStreamIdx = openCodecContext (&videoContext, AVMEDIA_TYPE_VIDEO, true);

--- a/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
+++ b/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.cpp
@@ -523,7 +523,7 @@ int FFmpegVideoReader::DecoderThread::decodeAudioPacket (AVPacket packet)
             }
             else {
                 outputNumSamples = numSamples;
-                audioConvertBuffer.setSize(channels, numSamples);
+                audioConvertBuffer.setSize(channels, numSamples, false, false, true);
                 swr_convert(audioConverterContext, (uint8_t**)audioConvertBuffer.getArrayOfWritePointers(), numSamples, (const uint8_t**)audioFrame->extended_data, numSamples);
                 audioFifo.addToFifo (audioConvertBuffer);
             }

--- a/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.h
+++ b/modules/filmstro_ffmpeg/filmstro_ffmpeg_FFmpegVideoReader.h
@@ -159,12 +159,14 @@ public:
         AVCodecContext*     videoContext;
         AVCodecContext*     audioContext;
         AVCodecContext*     subtitleContext;
+        SwrContext*         audioConverterContext;
 
         int                 videoStreamIdx;
         int                 audioStreamIdx;
         int                 subtitleStreamIdx;
 
         AVFrame*            audioFrame;
+        juce::AudioBuffer<float>  audioConvertBuffer;
 
         std::atomic<double> currentPTS;
 


### PR DESCRIPTION
These changes allow video files that do not store audio as non-interleaved floats to be played.
Frame and packet processing have been updated to the new API.